### PR TITLE
Fix mobile menu scrolling issues

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -10,6 +10,7 @@ hamburgerButton.addEventListener('click', () => {
   // Toggle the 'margin: auto' style on the element
   topLineHolder.style.margin = 'auto'
   menuSheet.classList.toggle('active')
+  document.body.classList.toggle('menu-open')
   // Centers the top line for mobile devices
   if (window.innerWidth < 500) {
     topOfPageElements.forEach((element) => {
@@ -92,6 +93,7 @@ function clear_all_rows() {
     'middle-eastern-row',
   ])
   menuSheet.classList.remove('active')
+  document.body.classList.remove('menu-open')
   make_row_title_disappear()
   removeRowTitles()
 }
@@ -219,6 +221,7 @@ const closeMenuLink = document.getElementById('close-menu')
 
 closeMenuLink.addEventListener('click', () => {
   menuSheet.classList.remove('active')
+  document.body.classList.remove('menu-open')
 })
 
 misc1Link.addEventListener('click', () => {

--- a/toplinks.css
+++ b/toplinks.css
@@ -345,6 +345,11 @@ footer {
     -100%
   ); /* Change from translateX(100%) to translateX(-100%) */
   transition: transform 0.5s ease-in-out;
+  overflow-y: auto;
+}
+
+.menu-open {
+  overflow: hidden;
 }
 
 .menu-sheet.active {


### PR DESCRIPTION
When the mobile menu is open, the background no longer scrolls. The menu itself is now scrollable if its content is taller than the viewport.

This is achieved by:
- Adding an `overflow: hidden` style to the body when the menu is active.
- Adding `overflow-y: auto` to the menu container.