### PR TITLE
Fix mobile menu scrolling issues

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -10,6 +10,7 @@ hamburgerButton.addEventListener('click', () => {
   // Toggle the 'margin: auto' style on the element
   topLineHolder.style.margin = 'auto'
   menuSheet.classList.toggle('active')
+  document.body.classList.toggle('menu-open')
   // Centers the top line for mobile devices
   if (window.innerWidth < 500) {
     topOfPageElements.forEach((element) => {
@@ -92,6 +93,7 @@ function clear_all_rows() {
     'middle-eastern-row',
   ])
   menuSheet.classList.remove('active')
+  document.body.classList.remove('menu-open')
   make_row_title_disappear()
   removeRowTitles()
 }
@@ -219,6 +221,7 @@ const closeMenuLink = document.getElementById('close-menu')
 
 closeMenuLink.addEventListener('click', () => {
   menuSheet.classList.remove('active')
+  document.body.classList.remove('menu-open')
 })
 
 misc1Link.addEventListener('click', () => {

--- a/toplinks.css
+++ b/toplinks.css
@@ -336,7 +336,7 @@ footer {
   top: 4em;
   left: 0; /* Change from right: 0 to left: 0 */
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 4em);
   background-color: #555;
   opacity: 0.94;
   color: #fff;
@@ -345,6 +345,11 @@ footer {
     -100%
   ); /* Change from translateX(100%) to translateX(-100%) */
   transition: transform 0.5s ease-in-out;
+  overflow-y: auto;
+}
+
+.menu-open {
+  overflow: hidden;
 }
 
 .menu-sheet.active {


### PR DESCRIPTION
This commit addresses two issues with the mobile menu:
1. The background would scroll when the menu was open.
2. The menu itself was not scrollable, and its content was cut off.

The following changes were made:
- An `overflow: hidden` style is now applied to the body when the menu is active to prevent background scrolling.
- The menu's height has been adjusted to `calc(100vh - 4em)` to fit within the viewport.
- `overflow-y: auto` has been added to the menu container to allow it to scroll if its content is taller than the viewport.